### PR TITLE
dsp judging & 4-rail support, SFX update and etc.

### DIFF
--- a/Scripts/AudioManager.cs
+++ b/Scripts/AudioManager.cs
@@ -4,6 +4,7 @@ public class AudioManager : MonoBehaviour
 {
     public static AudioManager Instance;
     public AudioSource musicSource;
+    public AudioClip defaultMusic;  
 
     void Awake()
     {
@@ -11,6 +12,18 @@ public class AudioManager : MonoBehaviour
         {
             Instance = this;
             DontDestroyOnLoad(gameObject);
+
+            if (musicSource == null)
+            {
+                musicSource = gameObject.AddComponent<AudioSource>();
+                musicSource.playOnAwake = false;
+            }
+
+            if (defaultMusic != null)
+            {
+                musicSource.clip = defaultMusic;
+                musicSource.playOnAwake = false;
+            }
         }
         else
         {
@@ -18,10 +31,10 @@ public class AudioManager : MonoBehaviour
         }
     }
 
-    public void PlayMusic(AudioClip clip)
+    public void PlayMusic()
     {
-        musicSource.clip = clip;
-        musicSource.Play();
+        if (!musicSource.isPlaying)
+            musicSource.Play();
     }
 
     public void PauseMusic()
@@ -33,5 +46,15 @@ public class AudioManager : MonoBehaviour
     public void ResumeMusic()
     {
         musicSource.UnPause();
+    }
+
+    public float GetMusicTimeInMs()
+    {
+        return musicSource.time * 1000f;
+    }
+
+    public double GetDspTimeInMs()
+    {
+        return AudioSettings.dspTime * 1000.0;
     }
 }

--- a/Scripts/ComboManager.cs
+++ b/Scripts/ComboManager.cs
@@ -1,24 +1,42 @@
 using UnityEngine;
+using TMPro;
 
 public class ComboManager : MonoBehaviour
 {
+    public AudioClip feverSfx;
     public GameObject yaySprite;
     public GameObject missSprite;
+    public TMP_Text comboText;
+    public TMP_Text totalScoreText;
 
-    private int totalComboCount = 0;
+    public int totalComboCount = 0;
+    public int totalScore = 0;
+    public int perfectScore = 100;
+    public int goodScore = 75;
+    public int fineScore = 50;
+
     private int recoveryComboCount = 0;
     private bool isInMissState = false;
+
+    public int comboHit = 0;
+    public int maxHit = 0;
 
     public int comboForFever = 10;   // Combo needed to trigger fever
     public int recoveryNeeded = 3;   // Hits needed to recover after a miss
 
+    void Start()
+    {
+        comboText.text = "x0";
+        totalScoreText.text = "0000000";
+
+    }
     public void RegisterPerfect()
     {
         Debug.Log("Perfect");
         HandleHit();
     }
 
-    public void RegisterGood()
+    public void RegisterHit()
     {
         Debug.Log("Good");
         HandleHit();
@@ -27,6 +45,12 @@ public class ComboManager : MonoBehaviour
     public void RegisterMiss()
     {
         Debug.Log("Miss");
+        if(comboHit>maxHit)
+        {
+            maxHit = comboHit;
+        }
+        comboHit = 0;
+        UpdateComboText();
 
         if (yaySprite.activeSelf)
         {
@@ -46,6 +70,8 @@ public class ComboManager : MonoBehaviour
     private void HandleHit()
     {
         totalComboCount++;
+        comboHit++;
+        UpdateComboText();
 
         if (isInMissState)
         {
@@ -63,8 +89,36 @@ public class ComboManager : MonoBehaviour
             !isInMissState &&
             totalComboCount >= comboForFever)
         {
+            Vector3 position = Camera.main.transform.position; 
+            AudioSource.PlayClipAtPoint(feverSfx, position, 3.0f); 
             GameManager.Instance.ActivateFeverMode();
             yaySprite.SetActive(true); 
         }
+    }
+
+    private void UpdateComboText()
+    {
+        if (comboHit > 0)
+        {comboText.text = $"x{comboHit}";}
+        else
+        {comboText.text = "x0"; }
+    }
+
+    public void UpdatePerfect()
+    {
+        totalScore =totalScore + perfectScore;
+        totalScoreText.text = totalScore.ToString("D7");
+    }
+
+    public void UpdateGood()
+    {
+        totalScore= totalScore + goodScore;
+        totalScoreText.text = totalScore.ToString("D7");
+    }
+
+    public void UpdateFine()
+    {
+        totalScore = totalScore + fineScore;
+        totalScoreText.text = totalScore.ToString("D7");
     }
 }

--- a/Scripts/GameManager.cs
+++ b/Scripts/GameManager.cs
@@ -8,7 +8,7 @@ public class GameManager : MonoBehaviour
     //Playing
     //Paused
     public string currentGameState = "Waiting";
-    public AudioSource musicSource; 
+    //public AudioSource musicSource; 
 
     public bool isFeverMode = false;
 
@@ -41,25 +41,39 @@ public class GameManager : MonoBehaviour
     {
         currentGameState = "Playing";
         isFeverMode = false;
+        AudioManager.Instance.PlayMusic();
         Debug.Log("Game Started");
     }
-    public void PauseGame()
-    {
-                if (musicSource.isPlaying)
-            musicSource.Pause();
+//     public void PauseGame()
+//     {
+//                 if (musicSource.isPlaying)
+//             musicSource.Pause();
         
-        Time.timeScale = 0;
-currentGameState = "Paused";
-        Debug.Log("Game Paused");
-    }
+//         Time.timeScale = 0;
+// currentGameState = "Paused";
+//         Debug.Log("Game Paused");
+//     }
 
-    public void ResumeGame()
-    {
-        currentGameState = "Playing";
-        Time.timeScale = 1;
-        musicSource.UnPause();
-        Debug.Log("Game Resumed");
-    }
+//     public void ResumeGame()
+//     {
+//         currentGameState = "Playing";
+//         Time.timeScale = 1;
+//         musicSource.UnPause();
+//         Debug.Log("Game Resumed");
+//     }
+public void PauseGame()
+{
+    AudioManager.Instance.PauseMusic();
+    Time.timeScale = 0;
+    currentGameState = "Paused";
+}
+
+public void ResumeGame()
+{
+    Time.timeScale = 1;
+    currentGameState = "Playing";
+    AudioManager.Instance.ResumeMusic();
+}
 
     public void ActivateFeverMode()
     {
@@ -75,6 +89,10 @@ currentGameState = "Paused";
     public void RestartGame()
     {
         Time.timeScale = 1f;
+        if (AudioManager.Instance != null)
+        {
+            Destroy(AudioManager.Instance.gameObject);
+        }
         string currentSceneName = SceneManager.GetActiveScene().name;
         SceneManager.LoadScene(currentSceneName);
         StartGame();
@@ -83,6 +101,10 @@ currentGameState = "Paused";
     public void LoadMainMenu()
     {
         SceneManager.LoadScene(0);
+        if (AudioManager.Instance != null)
+        {
+            Destroy(AudioManager.Instance.gameObject);
+        }
         WaitingGame();
         Debug.Log("Load Main Menu");
     }

--- a/Scripts/NoteHandler.cs
+++ b/Scripts/NoteHandler.cs
@@ -43,7 +43,6 @@
 //                     comboManager.RegisterGood();
 //                     isCorrectClicked = true;
 //                     int percentage = (int)(triggerRange * 100);
-//                     Debug.Log($"✅ Clicked note inside {percentage}% of target!");
 
 //                     GetComponent<Rigidbody2D>().velocity = Vector2.zero;  // Stop the note from moving
 //                     Animator noteAnimator = transform.GetChild(0).GetComponent<Animator>();
@@ -55,7 +54,6 @@
 //                 {
 //                     comboManager.RegisterMiss();
 //                     int percentage = (int)(triggerRange * 100);
-//                     Debug.Log($"❌ Clicked note but outside {percentage}% area, destroy after 5s.");
 //                 }
 //             }else{
 //                 comboManager.RegisterMiss();
@@ -65,28 +63,75 @@
 // }
 
 using UnityEngine;
+using System;
+using UnityEngine.SceneManagement;
 
-/// Handles note falling and click detection in rhythm game.
+
 public class NoteHandler : MonoBehaviour
 {
     public Transform targetCircle;    
-    public float allowedHitWindowMs = 150f; 
+
+    
+
+    //public AudioSource sfxSource;
+    public AudioClip perfectSfx;
+    public AudioClip goodSfx;
+    public AudioClip fineSfx;
+
+    public float perfectWindowMs = 50f;  
+    public float goodWindowMs = 100f;
+    public float fineWindowMs = 150f;
+
+    public GameObject missUIPrefab;
+    public GameObject perfectUI;
+    public GameObject goodUI;
+    public GameObject fineUI;
+
+
     public GameObject noteBoomVfx;
 
     private bool isCorrectClicked = false;
     private ComboManager comboManager;
 
-    [HideInInspector] public float targetTimeMs; 
-    public AudioSource musicSource; 
+    [HideInInspector] public double targetTimeMs; 
+    [HideInInspector] public int column;  
+
+    private Transform missUIParent;
 
     void Start()
     {
         comboManager = FindObjectOfType<ComboManager>();
+        int sceneIndex = SceneManager.GetActiveScene().buildIndex;
+        if(sceneIndex == 2)
+        {
+            missUIParent = GameObject.Find("Canvas").transform;
+        }else if(sceneIndex == 3)
+        {
+            missUIParent = GameObject.Find("CanvasFourRail").transform;
+        }
+        //AudioSource sfxSource = GameObject.Find("sfxSource").GetComponent<AudioSource>();
         Destroy(gameObject, 10f);
     }
 
     void Update()
     {
+        if (!isCorrectClicked)
+        {
+            double currentTimeMs = AudioManager.Instance.GetDspTimeInMs();
+            double lateWindowEnd = targetTimeMs + fineWindowMs;
+
+            if (currentTimeMs > lateWindowEnd)
+            {
+                isCorrectClicked = true;
+                comboManager.RegisterMiss();
+               
+                
+                MissUI();
+
+            }
+        }
+
+//------------------------------for mobile ---------------------      
         if (Input.GetMouseButtonDown(0) && !isCorrectClicked)
         {
             Vector3 clickPosition = Camera.main.ScreenToWorldPoint(Input.mousePosition);
@@ -96,14 +141,19 @@ public class NoteHandler : MonoBehaviour
 
             if (col != null && col.gameObject == gameObject)
             {
-                float currentTimeMs = musicSource.time * 1000f;
-                float delta = Mathf.Abs(currentTimeMs - targetTimeMs);
+                // float currentTimeMs = musicSource.time * 1000f;
+                // float delta = Mathf.Abs(currentTimeMs - targetTimeMs);
+                double currentTimeMs = AudioManager.Instance.GetDspTimeInMs();
+                double delta = Mathf.Abs((float)(currentTimeMs - targetTimeMs));
 
-                if (delta <= allowedHitWindowMs)
+                
+
+                if (delta <= fineWindowMs)
                 {
                     isCorrectClicked = true;
-                    comboManager.RegisterGood();
-                    Debug.Log($"Clicked within {delta}ms of target time!");
+                    comboManager.RegisterHit();
+                    //Debug.Log($"Clicked within {delta}ms of target time!");
+                    Judge(delta);
 
                     Animator noteAnimator = transform.GetChild(0).GetComponent<Animator>();
                     noteAnimator.SetBool("isDisappear", true);
@@ -112,9 +162,116 @@ public class NoteHandler : MonoBehaviour
                 else
                 {
                     comboManager.RegisterMiss();
-                    Debug.Log($"Clicked note too early/late: delta = {delta}ms");
+                    MissUI();
+                    Debug.Log($"Auto Miss! currentTime = {currentTimeMs}, targetTime = {targetTimeMs}");
                 }
             }
         }
+//------------------------------for mobile ---------------------      
+
+//------------------------------for win/mac ---------------------      
+        if (!isCorrectClicked && IsKeyForThisColumnPressed())
+        {
+            double currentTimeMs = AudioManager.Instance.GetDspTimeInMs();
+            double delta = Math.Abs(currentTimeMs - targetTimeMs);
+            
+            //Judge(delta);
+
+
+            if (delta <= fineWindowMs)
+            {
+                isCorrectClicked = true;
+                comboManager.RegisterHit();
+                //Debug.Log($"Key press hit on column {column} within {delta}ms");
+                Judge(delta);
+
+                Animator noteAnimator = transform.GetChild(0).GetComponent<Animator>();
+                noteAnimator.SetBool("isDisappear", true);
+                noteBoomVfx.SetActive(true);
+            }
+        }
+//------------------------------for win/mac ---------------------      
+
+
     }
+            private bool IsKeyForThisColumnPressed()
+        {
+            switch (column)
+            {
+                case 1: return Input.GetKeyDown(KeyCode.A);
+                case 2: return Input.GetKeyDown(KeyCode.S);
+                case 3: return Input.GetKeyDown(KeyCode.D);
+                case 4: return Input.GetKeyDown(KeyCode.F);
+                default: return false;
+            }
+        }
+
+        private void Judge(double delta)
+    {
+        if (delta <= perfectWindowMs)
+        {
+            Vector3 position = Camera.main.transform.position;
+            AudioSource.PlayClipAtPoint(perfectSfx, position, 4.0f); 
+            //isCorrectClicked = true;
+            //comboManager.RegisterGood();  
+            //totalScore = totalScore + perfectScore;
+            comboManager.UpdatePerfect();
+            Debug.Log($"Perfect! delta = {delta}ms");
+            perfectUI.SetActive(true);
+        }
+        else if (delta <= goodWindowMs)
+        {
+            Vector3 position = Camera.main.transform.position; 
+            AudioSource.PlayClipAtPoint(goodSfx, position, 5.0f); 
+            //isCorrectClicked = true;
+            //comboManager.RegisterGood();
+            //totalScore = totalScore + goodScore;
+            comboManager.UpdateGood();
+            Debug.Log($"Good! delta = {delta}ms");
+            goodUI.SetActive(true);
+        }
+        else if (delta <= fineWindowMs)
+        {
+            Vector3 position = Camera.main.transform.position; 
+            AudioSource.PlayClipAtPoint(fineSfx, position, 70.0f); 
+            //isCorrectClicked = true;
+            //comboManager.RegisterGood();
+            //totalScore = totalScore + fineScore;
+            comboManager.UpdateFine();
+            Debug.Log($"Fine! delta = {delta}ms");
+            fineUI.SetActive(true);
+        }
+        
+    }
+    private void MissUI()
+    {
+        Vector3 spawnPos = Vector3.zero;
+
+        int sceneIndex = SceneManager.GetActiveScene().buildIndex;
+        if(sceneIndex == 2)
+        {
+            if (column == 1)
+                spawnPos = new Vector3(-198f, -458f, 0f);
+            else if (column == 2)
+                spawnPos = new Vector3(48f, -458f, 0f);
+            else if (column == 3)
+                spawnPos = new Vector3(287f, -458f, 0f);
+        }else if(sceneIndex == 3)
+        {
+            if (column == 1)
+                spawnPos = new Vector3(-235f, -458f, 0f);
+            else if (column == 2)
+                spawnPos = new Vector3(-48f, -458f, 0f);
+            else if (column == 3)
+                spawnPos = new Vector3(143f, -458f, 0f);
+            else if (column == 4)
+                spawnPos = new Vector3(330f, -458f, 0f);
+        }
+
+
+        GameObject missUIInstance = Instantiate(missUIPrefab, missUIParent);
+        missUIInstance.GetComponent<RectTransform>().localPosition = spawnPos;
+        Destroy(missUIInstance, 1.0f);
+    }
+
 }

--- a/Scripts/UIManager.cs
+++ b/Scripts/UIManager.cs
@@ -1,16 +1,19 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using TMPro;
 
 public class UIManager : MonoBehaviour
 {
     public bool musicFinished = false;
     public GameObject resultEvent;
     public GameObject pauseEvent;
+    public TMP_Text finalResultText;
+    private ComboManager comboManager;
     // Start is called before the first frame update
     void Start()
     {
-        
+        comboManager = FindObjectOfType<ComboManager>();
     }
 
     // Update is called once per frame
@@ -44,6 +47,10 @@ public class UIManager : MonoBehaviour
     }
     void ResultEvent()
     {
+        string finalScore = comboManager.totalScoreText.text; 
+        int maxHit = comboManager.maxHit;
+
+        finalResultText.text = $"Final Score:\n{finalScore}\n\nMax Hit:\n{maxHit}";
         resultEvent.SetActive(true);
     }
 }


### PR DESCRIPTION
1. More accurate note judgment using DSP time;
2. 4-rail (four-lane) support;
3. Mascot animation for Fever state;
4. Auto-miss detection when miss window exceeded;
5. Perfect/Good/Fine/Unique SFX for each hit; 
6. special SFX in Fever mode; 
7. Fine-grained judgement (Perfect/Good/Fine) by DSP time (0–50/50–100/100–150 ms); 
8. Realtime score & combo counter, resets combo on miss; 
9. Result screen shows max combo (maxHit) and total score; 
10. Visual feedback for Perfect/Good/Fine above note; 
11. Miss spawns missUI at correct lane; 
12. Fix: Pause now also pauses music (AudioManager singleton); 
13. Testing: Keyboard ASDF maps to lanes 1–4 for convenience